### PR TITLE
use ensure_packages() rather than package to prevent conflicts with other modules

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,3 +9,4 @@ project_page 'https://github.com/enovance/puppet-ceph'
 
 dependency 'puppetlabs/apt', '>= 1.1.0'
 dependency 'ripienaar/concat', '>= 0.2.0'
+dependency 'puppetlabs/stdlib', '>= 4.1.0'

--- a/manifests/osd.pp
+++ b/manifests/osd.pp
@@ -25,7 +25,7 @@ class ceph::osd (
 
   include 'ceph::package'
 
-  package { ['xfsprogs', 'parted']:}
+  ensure_packages( 'xfsprogs', 'parted' )
 
   Package['ceph'] -> Ceph::Key <<| title == 'admin' |>>
 


### PR DESCRIPTION
my site currently manages xfsprogs and parted as base packages site wide.  Switching from using the builtin "Package" type to the stdlib provided "ensure_packages" function allows both to specify htis requirement without producing a conflict.

this also introduces a dependency on puppetlabs/stdlib
