### PR TITLE
fix typo in mds.pp

### DIFF
--- a/manifests/mds.pp
+++ b/manifests/mds.pp
@@ -64,3 +64,4 @@ define ceph::mds (
     status   => "service ceph status mds.${name}",
     require  => Exec['ceph-mds-keyring'],
   }
+}


### PR DESCRIPTION
There seems to be a missing closing bracket in mds.pp.
