### PR TITLE
Fixing puppet complaints of unqualified/no path

### DIFF
--- a/manifests/osd/device.pp
+++ b/manifests/osd/device.pp
@@ -26,21 +26,21 @@ define ceph::osd::device (
   $devname = regsubst($name, '.*/', '')
 
   exec { "mktable_gpt_${devname}":
-    command => "parted -a optimal --script ${name} mktable gpt",
-    unless  => "parted --script ${name} print|grep -sq 'Partition Table: gpt'",
+    command => "/sbin/parted -a optimal --script ${name} mktable gpt",
+    unless  => "/sbin/parted --script ${name} print|grep -sq 'Partition Table: gpt'",
     require => Package['parted']
   }
 
   exec { "mkpart_${devname}":
-    command => "parted -a optimal -s ${name} mkpart ceph 0% 100%",
-    unless  => "parted ${name} print | egrep '^ 1.*ceph$'",
+    command => "/sbin/parted -a optimal -s ${name} mkpart ceph 0% 100%",
+    unless  => "/sbin/parted ${name} print | egrep '^ 1.*ceph$'",
     require => [Package['parted'], Exec["mktable_gpt_${devname}"]]
   }
 
   exec { "mkfs_${devname}":
-    command => "mkfs.xfs -f -d agcount=${::processorcount} -l \
+    command => "/sbin/mkfs.xfs -f -d agcount=${::processorcount} -l \
 size=1024m -n size=64k ${name}1",
-    unless  => "xfs_admin -l ${name}1",
+    unless  => "/usr/sbin/xfs_admin -l ${name}1",
     require => [Package['xfsprogs'], Exec["mkpart_${devname}"]],
   }
 


### PR DESCRIPTION
Under:
- Ubuntu 12.04.3LTS
- Puppet agent 3.2.4-1puppetlabs1
- Puppetmaster 3.1.1-1puppetlabs1

Puppet complains that parted, xfs_admin and mkfs.xfs paths aren't specified.
I checked Debian Squeeze, Wheezy, Ubuntu 12.04 - paths are all the same (/sbin/parted, /sbin/mkfs.xfs and /usr/sbin/xfs_admin)

Respectively:
Error: Failed to apply catalog: Parameter unless failed on Exec[mktable_gpt_DEVICE]: 'parted --script DEVICE print|grep -sq 'Partition Table: gpt'' is not qualified and no path was specified. Please qualify the command or specify a path. at /etc/puppet/modules/ceph/manifests/osd/device.pp:32

Error: Failed to apply catalog: Parameter unless failed on Exec[mkfs_DEVICE]: 'xfs_admin -l /dev/DEVICE1' is not qualified and no path was specified. Please qualify the command or specify a path. at /etc/puppet/modules/ceph/manifests/osd/device.pp:45

Error: Failed to apply catalog: Validation of Exec[mkfs_DEVICE] failed: 'mkfs.xfs -f -d agcount=2 -l size=1024m -n size=64k /dev/DEVICE1' is not qualified and no path was specified. Please qualify the command or specify a path. at /etc/puppet/modules/ceph/manifests/osd/device.pp:45
