### PR TITLE
Start OSD during boot time

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -39,7 +39,8 @@ class ceph::conf (
   $mon_init_members        = undef,
   $osd_data                = '/var/lib/ceph/osd/osd.$id',
   $osd_journal             = undef,
-  $mds_data                = '/var/lib/ceph/mds/mds.$id'
+  $mds_data                = '/var/lib/ceph/mds/mds.$id',
+  $enable_service          = false,
 ) {
 
   include 'ceph::package'
@@ -65,4 +66,5 @@ class ceph::conf (
     content => template('ceph/ceph.conf.erb'),
   }
 
+  service { 'ceph': enable => $enable_service }
 }

--- a/manifests/osd.pp
+++ b/manifests/osd.pp
@@ -28,7 +28,4 @@ class ceph::osd (
   ensure_packages( [ 'xfsprogs', 'parted' ] )
 
   Package['ceph'] -> Ceph::Key <<| title == 'admin' |>>
-
-  service { 'ceph': enable => true }
 }
-


### PR DESCRIPTION
Prior to this patch OSD daemons were not started during the boot
sequence.

Closes bug: #41
