### PR TITLE
Revert "Manage osd journal as a lvm"

### DIFF
--- a/manifests/osd/device.pp
+++ b/manifests/osd/device.pp
@@ -75,16 +75,6 @@ size=1024m -n size=64k ${name}1",
         ensure => directory,
       }
 
-      file { "${osd_data}/journal":
-        ensure  => link,
-        target  => "/dev/mapper/rootfs-journal--${devname}1",
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0660',
-        require => Mount[$osd_data],
-        before  => Service["ceph-osd.${osd_id}"];
-      }
-
       mount { $osd_data:
         ensure  => mounted,
         device  => "${name}1",


### PR DESCRIPTION
This reverts commit ae66e2226aab65fd1a448866b6ac0a9661b5ac6e.

By default, ceph OSD stores its journal in a regular file at
"${osd_data}/journal". This file is created when the OSD is first launched.
With this commit, the "${osd_data}/journal" resource is now managed by Puppet
and replaced by a symlink to a non-existent (in our setup) LVM device.

Result is that the actual journal content gets deleted (and fortunately backed
up in Puppet's clientbucket) and a broken symlink is installed instead.

This is why I think that this commit should be either reverted or that the
File["${osd_data}/journal"] resource should depend on a new parameter which
defaults to false.
