### PR TITLE
Add path to exec ressources so the module can be standalone

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -8,6 +8,7 @@ define ceph::key (
   exec { "ceph-key-${name}":
     command => "ceph-authtool ${keyring_path} --create-keyring --name='client.${name}' --add-key='${secret}'",
     creates => $keyring_path,
+    path    => '/usr/bin',
     require => Package['ceph'],
   }
 

--- a/manifests/mds.pp
+++ b/manifests/mds.pp
@@ -50,8 +50,9 @@ define ceph::mds (
   }
 
   exec { 'ceph-mds-keyring':
-    command =>"ceph auth get-or-create mds.${name} mds 'allow ' osd 'allow *' mon 'allow rwx'",
+    command => "ceph auth get-or-create mds.${name} mds 'allow ' osd 'allow *' mon 'allow rwx'",
     creates => "/var/lib/ceph/mds/mds.${name}/keyring",
+    path    => '/usr/bin',
     before  => Service["ceph-mds.${name}"],
     require => Package['ceph'],
   }

--- a/manifests/mon.pp
+++ b/manifests/mon.pp
@@ -52,6 +52,7 @@ define ceph::mon (
 --add-key='${monitor_secret}' \
 --cap mon 'allow *'",
     creates => "/var/lib/ceph/tmp/keyring.mon.${name}",
+    path    => '/usr/bin',
     before  => Exec['ceph-mon-mkfs'],
     require => Package['ceph'],
   }
@@ -60,6 +61,7 @@ define ceph::mon (
     command => "ceph-mon --mkfs -i ${name} \
 --keyring /var/lib/ceph/tmp/keyring.mon.${name}",
     creates => "${mon_data_real}/keyring",
+    path    => '/usr/bin',
     require => [
       Package['ceph'],
       Concat['/etc/ceph/ceph.conf'],
@@ -95,6 +97,7 @@ $(ceph --name mon. --keyring ${mon_data_real}/keyring \
     osd 'allow *' \
     mds allow)",
     creates => '/etc/ceph/keyring',
+    path    => '/usr/bin',
     require => Package['ceph'],
     onlyif  => "ceph --admin-daemon /var/run/ceph/ceph-mon.${name}.asok \
 mon_status|egrep -v '\"state\": \"(leader|peon)\"'",


### PR DESCRIPTION
The module was missing path parameter for its exec ressources.
This make it depend on path defaults to be set before the module
was run. With this commit module does not depend on default being
set before.
