### PR TITLE
packaging: manage mon and osd in /var/lib/ceph

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -26,18 +26,11 @@ class ceph::package (
 
   #FIXME: Ensure ceph user/group
 
-  file { '/var/lib/ceph':
-    ensure => directory,
-    owner  => 'root',
-    group  => 0,
-    mode   => '0755'
-  }
-
-  file { '/var/run/ceph':
-    ensure => directory,
-    owner  => 'root',
-    group  => 0,
-    mode   => '0755'
-  }
+  ensure_resource('file', ['/var/run/ceph', '/var/lib/ceph', '/var/lib/ceph/mon', '/var/lib/ceph/osd'], {
+    'ensure' => 'directory',
+    'owner'  => 'root',
+    'group'  => '0',
+    'mode'   => '0755'
+  })
 
 }

--- a/spec/classes/ceph_package_spec.rb
+++ b/spec/classes/ceph_package_spec.rb
@@ -11,6 +11,20 @@ describe 'ceph::package' do
       'mode'   => '0755'
     ) }
 
+    it { should contain_file('/var/lib/ceph/mon').with(
+      'ensure' => 'directory',
+      'owner'  => 'root',
+      'group'  => 0,
+      'mode'   => '0755'
+    ) }
+
+    it { should contain_file('/var/lib/ceph/osd').with(
+      'ensure' => 'directory',
+      'owner'  => 'root',
+      'group'  => 0,
+      'mode'   => '0755'
+    ) }
+
     it { should contain_file('/var/run/ceph').with(
       'ensure' => 'directory',
       'owner'  => 'root',


### PR DESCRIPTION
- Manage /var/lib/ceph/{mon,osd}
- Use stdlib to avoid resource dupplication
- Factorize folders in an array
