### PR TITLE
spec: Gemfile - pin gems to rspec < 2.99

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 bundler_args: --without development
-script: "bundle exec rake SPEC_OPTS='--format documentation --color --backtrace'"
+script: "bundle exec rake spec SPEC_OPTS='--format documentation --color --backtrace'"
 rvm:
   - 1.8.7
   - 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,17 @@
 source "https://rubygems.org"
 
-if ENV.key?('PUPPET_VERSION')
-    puppetversion = ENV['PUPPET_VERSION']
-else
-    puppetversion = ['>= 2.7']
+group :development, :test do
+  gem 'puppetlabs_spec_helper', :require => false
+  gem 'puppet-lint', '~> 0.3.2'
+  gem 'rake', '10.1.0'
+  gem 'rspec', '< 2.99'
+  gem 'puppet-syntax'
 end
 
-gem 'rake', '10.1.0'
-gem 'puppet-lint', '~> 0.3.2'
-gem 'rspec-puppet'
-gem 'puppet-syntax'
-gem 'puppetlabs_spec_helper'
-gem 'puppet', puppetversion
+if puppetversion = ENV['PUPPET_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+# vim:ft=ruby


### PR DESCRIPTION
Pin to rspec < 2.99 until rspec-puppet officially supports rspec 3.x.
This is to avoid warnings due to deprecated matchers in the rspec-puppet
gem.

See: https://launchpad.net/bugs/1326034
