### PR TITLE
Increase ceph keyring timeout

### DIFF
--- a/lib/facter/ceph_keyring.rb
+++ b/lib/facter/ceph_keyring.rb
@@ -6,8 +6,8 @@
 require 'facter'
 require 'json'
 
-timeout = 2
-cmd_timeout = 2
+timeout = 10
+cmd_timeout = 10
 
 begin
   Timeout::timeout(timeout) {


### PR DESCRIPTION
Sometimes, 2 seconds for creating the ceph keyring is too short and can
lead to Puppet timeouts.
Let's use 10s by default to avoid this situation..
