### PR TITLE
Use sane default XFS options (same as ceph-disk)

### DIFF
--- a/manifests/osd/device.pp
+++ b/manifests/osd/device.pp
@@ -40,8 +40,7 @@ define ceph::osd::device (
   }
 
   exec { "mkfs_${devname}":
-    command => "mkfs.xfs -f -d agcount=${::processorcount} -l \
-size=1024m -n size=64k ${name}1",
+    command => "mkfs.xfs -f -i size=2048 ${name}1",
     unless  => "xfs_admin -l ${name}1",
     require => [Package['xfsprogs'], Exec["mkpart_${devname}"]],
   }

--- a/spec/defines/ceph_osd_device_spec.rb
+++ b/spec/defines/ceph_osd_device_spec.rb
@@ -43,7 +43,7 @@ class { 'ceph::osd':
     ) }
 
     it { should contain_exec('mkfs_device').with(
-      'command' => 'mkfs.xfs -f -d agcount=8 -l size=1024m -n size=64k /dev/device1',
+      'command' => 'mkfs.xfs -f -i size=2048 /dev/device1',
       'unless'  => 'xfs_admin -l /dev/device1',
       'require' => ['Package[xfsprogs]', 'Exec[mkpart_device]']
     ) }


### PR DESCRIPTION
This should prevent cluster from being deployed with exotic and potentially
harmful XFS options such as '-n size=64k' which may lead to OSD crashes or even
data corruption.

References:
- http://lists.ceph.com/pipermail/ceph-users-ceph.com/2014-July/041336.html
- http://tracker.ceph.com/issues/6301

The new options were taken from ceph upstream recommendation in the ceph-disk
utility.
See https://github.com/ceph/ceph/blob/master/src/ceph-disk#L101:
