### PR TITLE
Fix admin keyring exported resources.

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -9,7 +9,7 @@ define ceph::key (
 
   exec { "ceph-key-${name}":
     command => "ceph-authtool ${keyring_path} --create-keyring --name=${name} --add-key='${secret}' ${capabilities_str}",
-    creates => $keyring_path,
+    unless => "grep ${secret} ${keyring_path}",
     require => Pacakge['ceph'],
   }
 


### PR DESCRIPTION
When used in a 3 nodes configuration the exported key doesn't overwrite the one already generated on the node. Because the exported key is the only one that is added to ceph.conf, you cannot connect to ceph cluster from the others nodes.
