### PR TITLE
Fixing admin keyring exported resources.

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -1,13 +1,13 @@
 # Create the ceph keyring
 #
 define ceph::key (
-  $secret       = undef,
+  $secret,
   $keyring_path = "/var/lib/ceph/tmp/${name}.keyring",
 ) {
 
   exec { "ceph-key-${name}":
     command => "ceph-authtool ${keyring_path} --create-keyring --name='client.${name}' --add-key='${secret}'",
-    creates => $keyring_path,
+    unless => "grep ${secret} ${keyring_path}",
     require => Package['ceph'],
   }
 

--- a/spec/defines/ceph_key_spec.rb
+++ b/spec/defines/ceph_key_spec.rb
@@ -6,32 +6,25 @@ describe 'ceph::key' do
     'dummy'
   end
 
-  describe 'with default parameters' do
-    it { should contain_exec('ceph-key-dummy').with(
-      'command' => "ceph-authtool /var/lib/ceph/tmp/dummy.keyring --create-keyring --name='client.dummy' --add-key=''",
-      'creates' => '/var/lib/ceph/tmp/dummy.keyring',
-      'require' => 'Package[ceph]'
-    )}
-  end
-
-  describe 'wen setting secret' do
+  describe 'with default parameter' do
     let :params do
       { :secret => 'shhh_dont_tell_anyone' }
     end
     it { should contain_exec('ceph-key-dummy').with(
       'command' => "ceph-authtool /var/lib/ceph/tmp/dummy.keyring --create-keyring --name='client.dummy' --add-key='shhh_dont_tell_anyone'",
-      'creates' => '/var/lib/ceph/tmp/dummy.keyring',
+      'unless' => "grep shhh_dont_tell_anyone /var/lib/ceph/tmp/dummy.keyring",
       'require' => 'Package[ceph]'
     )}
   end
 
-  describe 'wen overriding keyring_path' do
+  describe 'when setting secret and overriding keyring_path' do
     let :params do
-      { :keyring_path => '/dummy/path/for/keyring' }
+      { :secret => 'shhh_dont_tell_anyone',
+        :keyring_path => '/dummy/path/for/keyring' }
     end
     it { should contain_exec('ceph-key-dummy').with(
-      'command' => "ceph-authtool /dummy/path/for/keyring --create-keyring --name='client.dummy' --add-key=''",
-      'creates' => '/dummy/path/for/keyring',
+      'command' => "ceph-authtool /dummy/path/for/keyring --create-keyring --name='client.dummy' --add-key='shhh_dont_tell_anyone'",
+      'unless' => 'grep shhh_dont_tell_anyone /dummy/path/for/keyring',
       'require' => 'Package[ceph]'
     )}
   end


### PR DESCRIPTION
When used in a 3 nodes configuration the exported key doesn't overwrite the one already generated on the node. Because the exported key is the
only one that is added to ceph.conf, you cannot connect to ceph cluster
from the others nodes.
Also the admin key should never be empty since when you do that
ceph-authtool just create an empty file.
