### PR TITLE
ceph_osd_bootstrap_key fact: increase timeout

### DIFF
--- a/lib/facter/ceph_osd_bootstrap_key.rb
+++ b/lib/facter/ceph_osd_bootstrap_key.rb
@@ -10,8 +10,8 @@
 require 'facter'
 require 'timeout'
 
-timeout = 2
-cmd_timeout = 2
+timeout = 10
+cmd_timeout = 10
 
 # ceph_osd_bootstrap_key
 # Fact that gets the ceph key "client.bootstrap-osd"


### PR DESCRIPTION
Like we do in ceph_keyring fact with 10 seconds, let's increase the
timeout to avoid this situation when compiling the catalog:

ceph command timeout in ceph_osd_bootstrap_key fact
Traceback (most recent call last):
  File "/usr/bin/ceph", line 830, in <module>
    sys.exit(main())
  File "/usr/bin/ceph", line 819, in main
    sys.stdout.flush()
IOError: [Errno 32] Broken pipe

10 seconds is the same value as in ceph_keyring fact.
