### PR TITLE
ceph_osd_bootstrap_key fact: Fix uuid detection

### DIFF
--- a/lib/facter/ceph_osd_bootstrap_key.rb
+++ b/lib/facter/ceph_osd_bootstrap_key.rb
@@ -48,7 +48,7 @@ end
 
 blkid = Facter::Util::Resolution.exec("blkid")
 blkid and blkid.each_line do |line|
-  if line =~ /^\/dev\/(.+):.*UUID="([a-fA-F0-9\-]+)"/
+  if line =~ /^\/dev\/(.+):\s*UUID="([a-fA-F0-9\-]+)"/
     device = $1
     uuid = $2
 


### PR DESCRIPTION
Util-linux v2.22 introduced PARTUUID to blkid command [1].
With this new version used in Debian 8, RHEL7 or Ubuntu 14.04 the osd uuid
detection doesn't match with UUID value but PARTUUID.

Before v2.22:
/dev/sdb1: UUID="056f8353-b027-41ec-b1fb-50fa89220086" TYPE="xfs"

From v2.22:
/dev/sdb1: UUID="056f8353-b027-41ec-b1fb-50fa89220086" TYPE="xfs" PARTLABEL="ceph" PARTUUID="93a6db61-6fd3-431c-9ae7-ad79442916f7"

The result is a creation of new osd(s) on each puppet run.

This patch fixes the blkid regex in ceph_osd_bootstrap_key fact.

[1] https://www.kernel.org/pub/linux/utils/util-linux/v2.22/v2.22-ReleaseNotes

Signed-off-by: Dimitri Savineau dimitri.savineau@enovance.com
