### PR TITLE
New forge release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+##2014-12-10 - release 1.3.0
+
+###Summary
+* Added ceph::client class (to configure ceph clients)
+* Drop unit-testing on puppet 2.7 series
+* Added puppet header in generated configs files
+
+####Bugfixes
+* Bugfix with uuid detection (ceph_osd_bootstrap_key fact), introduced with blkid >= v2.22
+* Remove non-UTF8 chars, refs https://tickets.puppetlabs.com/browse/PUP-1386
+
 ##2014-10-08 - release 1.2.0
 
 ###Summary

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "eNovance-ceph",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Francois Charlier <francois.charlier@enovance.com>",
   "summary": "A puppet module to install & configure Ceph",
   "license": "AGPLv3",


### PR DESCRIPTION
- Summary
  - Added ceph::client class (to configure ceph clients)
  - Drop unit-testing on puppet 2.7 series
  - Added puppet header in generated configs files
- Bugfixes
  - Bugfix with uuid detection (ceph_osd_bootstrap_key fact), introduced with blkid >= v2.22
  - Remove non-UTF8 chars, refs https://tickets.puppetlabs.com/browse/PUP-1386

Kudo to François and Dimitri for this release!
