### PR TITLE
Fix the ceph::client class …

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -48,7 +48,7 @@ class ceph::client (
   $keys
 ) {
 
-  package { 'ceph-common':
+  package { 'ceph':
     ensure => present
   }
 
@@ -57,7 +57,7 @@ class ceph::client (
     group   => '0',
     mode    => '0644',
     content => template('ceph/ceph-client.conf.erb'),
-    require => Package['ceph-common']
+    require => Package['ceph']
   }
 
   create_resources('ceph::key', $keys)

--- a/spec/classes/ceph_client_spec.rb
+++ b/spec/classes/ceph_client_spec.rb
@@ -40,8 +40,8 @@ describe 'ceph::client' do
       }
     end
 
-    it 'installs the ceph-common package' do
-      should contain_package('ceph-common').with_ensure('present')
+    it 'installs the ceph package' do
+      should contain_package('ceph').with_ensure('present')
     end
 
     it 'creates a correct configuration file' do
@@ -63,7 +63,18 @@ auth_supported = cephx
     keyring = /var/lib/ceph/tmp/user1.keyring
 
 ',
-        :require => 'Package[ceph-common]'
+        :require => 'Package[ceph]'
+      )
+    end
+
+    it 'creates the keys' do
+      should contain_ceph__key('admin').with(
+        :secret       => 'some-secret',
+        :keyring_path => '/etc/ceph/ceph.client.admin.keyring'
+      )
+      should contain_ceph__key('user1').with(
+        :secret       => 'some-other-secret',
+        :keyring_path => '/var/lib/ceph/tmp/user1.keyring'
       )
     end
 


### PR DESCRIPTION
Some tests were missing to make sure the keys were created.
The dependency against the `ceph-common` package is changed to `ceph` instead because `ceph::key` depends on the latter.

Sorry for this :disappointed: 
